### PR TITLE
fix word alignement to close #22

### DIFF
--- a/abkhazia/align/align.py
+++ b/abkhazia/align/align.py
@@ -31,7 +31,6 @@ two alignment recipes, the Align recipe seems to add more silences.
 """
 
 import gzip
-import ipdb
 import os
 import shutil
 import numpy as np
@@ -331,7 +330,6 @@ class Align(abstract_recipe.AbstractRecipe):
         start = 0
         stop = 0
         for utt_id, alignment in self._read_utts(path):
-
             for line in self._read_splited(alignment):
                 phone = line[3]
                 if len(line) == 5:  # new word

--- a/abkhazia/align/align.py
+++ b/abkhazia/align/align.py
@@ -31,6 +31,7 @@ two alignment recipes, the Align recipe seems to add more silences.
 """
 
 import gzip
+import ipdb
 import os
 import shutil
 import numpy as np
@@ -324,14 +325,15 @@ class Align(abstract_recipe.AbstractRecipe):
                 alignment.append(' '.join(line))
         yield utt_id, alignment
 
-    @classmethod
-    def _read_words(cls, path):
+    def _read_words(self, path):
         """Yield words alignement from a 'phone and words' alignment file"""
         word = None
         start = 0
         stop = 0
-        for utt_id, alignment in cls._read_utts(path):
-            for line in cls._read_splited(alignment):
+        for utt_id, alignment in self._read_utts(path):
+
+            for line in self._read_splited(alignment):
+                phone = line[3]
                 if len(line) == 5:  # new word
                     if word is not None:
                         yield ' '.join([utt_id, start, stop, word])
@@ -339,6 +341,9 @@ class Align(abstract_recipe.AbstractRecipe):
                     # utt_id = line[0]
                     start = line[1]
                     stop = line[2]
+                elif (phone in self.corpus.silences): 
+                    # Don't count SIL as part of the word
+                    continue
                 else:  # word continues
                     stop = line[2]
 

--- a/abkhazia/align/align.py
+++ b/abkhazia/align/align.py
@@ -396,6 +396,11 @@ class Align(abstract_recipe.AbstractRecipe):
             index = self._align_phone(phone, alignment, index)
             if n == 0:
                 alignment[index] += f' {word}'
+
+        # go to next phone, in case next word starts with same
+        # phone
+        index += 1
+
         return alignment, index
 
     @staticmethod

--- a/abkhazia/align/align.py
+++ b/abkhazia/align/align.py
@@ -370,17 +370,18 @@ class Align(abstract_recipe.AbstractRecipe):
 
         # align the utterance word by word
         index = 0
-        try:
-            for word in words:
+        for word in words:
+            try:
                 utt_align, index = self._align_word(word, utt_align, index)
-        except IndexError:
-            self.log.warning(
-                f'failed to align words from phones on utterance {utt_id}: '
-                f'phones dont match word')
-        except KeyError as err:
-            self.log.warning(
-                f'failed to align words from phones on utterance {utt_id}: '
-                f'{str(err)}')
+            except IndexError:
+                self.log.warning(
+                    f'failed to align words from phones on utterance {utt_id}: '
+                    f'phones dont match word')
+            except KeyError as err:
+                self.log.warning(
+                    f'failed to align words from phones on utterance {utt_id}: '
+                    f'{str(err)}')
+
 
         return utt_align
 


### PR DESCRIPTION
Don't count Silences timestamps for word alignements. 
2 cases : 
- Silence is in middle of word : next phoneme still sets "stop" var for word 
- Silence is in the end of the word : don't count Silence as part of word