### PR TITLE
Fix zip usage for compatibility with python 3 

### DIFF
--- a/abkhazia/corpus/corpus_filter.py
+++ b/abkhazia/corpus/corpus_filter.py
@@ -55,8 +55,8 @@ class CorpusFilter(object):
         self.corpus = corpus
 
         # read utt2spk from the input corpus
-        utt_ids, utt_speakers = zip(*self.corpus.utt2spk.items())
-        self.utts = zip(utt_ids, utt_speakers)
+        utt_ids, utt_speakers = list(zip(*self.corpus.utt2spk.items()))
+        self.utts = list(zip(utt_ids, utt_speakers))
         self.size = len(utt_ids)
         self.speakers = set(utt_speakers)
         self.limits = dict()
@@ -180,9 +180,9 @@ class CorpusFilter(object):
         # create lists of utterances we want to keep,
         # utterances we don't want to keep
         for speaker in names:
-            utt_and_dur = zip(spk2utts[speaker],
+            utt_and_dur = list(zip(spk2utts[speaker],
                               [utt2dur[utt] for utt
-                              in spk2utts[speaker]])
+                              in spk2utts[speaker]]))
             decreasing_utts = sorted(utt_and_dur,
                                      key=lambda utt_and_dur: utt_and_dur[1],
                                      reverse=True)

--- a/abkhazia/corpus/corpus_merge_wavs.py
+++ b/abkhazia/corpus/corpus_merge_wavs.py
@@ -57,8 +57,8 @@ class CorpusMergeWavs(object):
         self.log = log
         self.corpus = corpus
         # read utt2spk from the input corpus
-        utt_ids, utt_speakers = zip(*self.corpus.utt2spk.items())
-        self.utts = zip(utt_ids, utt_speakers)
+        utt_ids, utt_speakers = list(zip(*self.corpus.utt2spk.items()))
+        self.utts = list(zip(utt_ids, utt_speakers))
         self.size = len(utt_ids)
         self.speakers = set(utt_speakers)
         self.segments = self.corpus.segments

--- a/abkhazia/corpus/corpus_split.py
+++ b/abkhazia/corpus/corpus_split.py
@@ -59,7 +59,7 @@ class CorpusSplit(object):
         random.seed(random_seed)
 
         # read utt2spk from the input corpus
-        utt_ids, utt_speakers = zip(*self.corpus.utt2spk.items())
+        utt_ids, utt_speakers = list(zip(*self.corpus.utt2spk.items()))
         self.utts = list(zip(utt_ids, utt_speakers))
         self.size = len(utt_ids)
         self.speakers = set(utt_speakers)

--- a/abkhazia/corpus/corpus_trimmer.py
+++ b/abkhazia/corpus/corpus_trimmer.py
@@ -44,8 +44,8 @@ class CorpusTrimmer(object):
         self.log = log
         self.corpus = corpus
 
-        utt_ids, utt_speakers = zip(*self.corpus.utt2spk.items())
-        self.utts = zip(utt_ids, utt_speakers)
+        utt_ids, utt_speakers = list(zip(*self.corpus.utt2spk.items()))
+        self.utts = list(zip(utt_ids, utt_speakers))
         self.speakers = set(utt_speakers)
 
     def trim(self, corpus_dir, output_dir, function, not_kept_utts):

--- a/abkhazia/corpus/prepare/globalphone_abstract_preparator.py
+++ b/abkhazia/corpus/prepare/globalphone_abstract_preparator.py
@@ -125,7 +125,7 @@ class AbstractGlobalPhonePreparator(AbstractPreparator):
         wavs = [
             os.path.basename(shn).replace('.adc.shn', '.wav') for shn in shns]
 
-        return zip(shns, wavs)
+        return list(zip(shns, wavs))
 
     def make_segment(self):
         segments = dict()

--- a/abkhazia/corpus/prepare/librispeech_preparator.py
+++ b/abkhazia/corpus/prepare/librispeech_preparator.py
@@ -128,7 +128,7 @@ class LibriSpeechPreparator(AbstractPreparatorWithCMU):
             wavs.append(prefix + utt_id + '.wav')
 
         self._wavs = wavs
-        return zip(flacs, wavs)
+        return list(zip(flacs, wavs))
 
     def make_segment(self):
         segments = dict()

--- a/abkhazia/corpus/prepare/xitsonga_preparator.py
+++ b/abkhazia/corpus/prepare/xitsonga_preparator.py
@@ -131,7 +131,7 @@ class XitsongaPreparator(AbstractPreparator):
         self._wavs = [os.path.basename(wav).replace('nchlt_tso_', '')
                       for wav in inputs]
 
-        return zip(inputs, self._wavs)
+        return list(zip(inputs, self._wavs))
 
     def make_segment(self):
         segments = dict()


### PR DESCRIPTION
In Python 3, `zip` returns an iterator and not a list as in Python 2: it exhausts once it has been iterated over.

This behaviour causes issues in
https://github.com/bootphon/abkhazia/blob/79632be7283cfc51805d15e4c84005708770bb6f/abkhazia/corpus/corpus_merge_wavs.py#L87-L89
as `self.utts` is defined in
https://github.com/bootphon/abkhazia/blob/79632be7283cfc51805d15e4c84005708770bb6f/abkhazia/corpus/corpus_merge_wavs.py#L61
For the first `spkr`, `spk_utts` is correct, but for the next ones it is an empty list as `self.utts` is exhausted.

This PR fixes this by changing `zip(...)` to `list(zip(...))`.